### PR TITLE
Persist QuickBooks Time data in PostgreSQL

### DIFF
--- a/lib/quickbooks_time/db/schema.rb
+++ b/lib/quickbooks_time/db/schema.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module QuickbooksTime
+  module DB
+    module Schema
+      module_function
+
+      def ensure!(conn)
+        create_users(conn)
+        create_jobs(conn)
+        create_timesheets(conn)
+        create_sync_logs(conn)
+        ensure_timesheet_meta_columns(conn)
+        create_timesheet_index(conn)
+      end
+
+      def create_users(conn)
+        conn.exec(<<~SQL)
+          CREATE TABLE IF NOT EXISTS quickbooks_time_users (
+            id BIGINT PRIMARY KEY,
+            first_name TEXT,
+            last_name TEXT,
+            username TEXT,
+            email TEXT,
+            active BOOLEAN,
+            last_modified TIMESTAMPTZ,
+            created TIMESTAMPTZ,
+            raw JSONB
+          );
+        SQL
+      end
+
+      def create_jobs(conn)
+        conn.exec(<<~SQL)
+          CREATE TABLE IF NOT EXISTS quickbooks_time_jobs (
+            id BIGINT PRIMARY KEY,
+            parent_id BIGINT,
+            name TEXT,
+            short_code TEXT,
+            type TEXT,
+            billable BOOLEAN,
+            billable_rate NUMERIC,
+            has_children BOOLEAN,
+            assigned_to_all BOOLEAN,
+            required_customfields JSONB,
+            filtered_customfielditems JSONB,
+            active BOOLEAN,
+            last_modified TIMESTAMPTZ,
+            created TIMESTAMPTZ
+          );
+        SQL
+      end
+
+      def create_timesheets(conn)
+        conn.exec(<<~SQL)
+          CREATE TABLE IF NOT EXISTS quickbooks_time_timesheets (
+            id BIGINT PRIMARY KEY,
+            quickbooks_time_jobsite_id BIGINT NOT NULL,
+            user_id BIGINT NOT NULL,
+            date DATE NOT NULL,
+            duration_seconds INTEGER NOT NULL,
+            notes TEXT,
+            last_hash TEXT,
+            billed BOOLEAN NOT NULL DEFAULT false,
+            billed_invoice_id TEXT,
+            entry_type TEXT,
+            start_time TIMESTAMPTZ,
+            end_time TIMESTAMPTZ,
+            created_qbt TIMESTAMPTZ,
+            modified_qbt TIMESTAMPTZ,
+            created_at TIMESTAMPTZ DEFAULT now(),
+            updated_at TIMESTAMPTZ DEFAULT now()
+          );
+        SQL
+      end
+
+      def create_sync_logs(conn)
+        conn.exec(<<~SQL)
+          CREATE TABLE IF NOT EXISTS api_sync_logs (
+            id SERIAL PRIMARY KEY,
+            api_name VARCHAR NOT NULL UNIQUE,
+            last_successful_sync TIMESTAMPTZ,
+            last_id BIGINT
+          );
+        SQL
+      end
+
+      def ensure_timesheet_meta_columns(conn)
+        conn.exec(<<~SQL)
+          ALTER TABLE quickbooks_time_timesheets
+            ADD COLUMN IF NOT EXISTS entry_type TEXT,
+            ADD COLUMN IF NOT EXISTS start_time TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS end_time TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS created_qbt TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS modified_qbt TIMESTAMPTZ;
+        SQL
+      end
+
+      def create_timesheet_index(conn)
+        conn.exec(<<~SQL)
+          CREATE INDEX IF NOT EXISTS idx_qbt_job_unbilled
+            ON quickbooks_time_timesheets (quickbooks_time_jobsite_id)
+            WHERE billed = false;
+        SQL
+      end
+    end
+  end
+end
+

--- a/lib/quickbooks_time/repos/cursor_store.rb
+++ b/lib/quickbooks_time/repos/cursor_store.rb
@@ -3,9 +3,13 @@
 require 'time'
 
 class CursorStore
-  def initialize
-    @timestamp = Time.at(0).utc.iso8601
-    @id = 0
+  API_NAME = 'quickbooks_time_timesheets'
+
+  def initialize(db:)
+    @db = db
+    row = @db.exec_params('SELECT last_successful_sync, last_id FROM api_sync_logs WHERE api_name=$1', [API_NAME]).first
+    @timestamp = row && row['last_successful_sync'] ? Time.parse(row['last_successful_sync']).utc.iso8601 : Time.at(0).utc.iso8601
+    @id = row && row['last_id'] ? row['last_id'].to_i : 0
   end
 
   def read
@@ -15,5 +19,13 @@ class CursorStore
   def write(ts, id)
     @timestamp = ts
     @id = id
+    @db.exec_params(
+      'INSERT INTO api_sync_logs (api_name, last_successful_sync, last_id)
+       VALUES ($1,$2,$3)
+       ON CONFLICT (api_name) DO UPDATE SET
+         last_successful_sync=EXCLUDED.last_successful_sync,
+         last_id=EXCLUDED.last_id',
+      [API_NAME, ts, id]
+    )
   end
 end

--- a/lib/quickbooks_time/repos/jobs_repo.rb
+++ b/lib/quickbooks_time/repos/jobs_repo.rb
@@ -1,14 +1,41 @@
 # frozen_string_literal: true
 
+require 'json'
+
 class JobsRepo
-  def initialize
-    @data = {}
+  def initialize(db:)
+    @db = db
   end
 
   def upsert(job)
     id = job['id'] || job[:id]
-    changed = @data[id] != job
-    @data[id] = job
+    last_modified = job['last_modified'] || job[:last_modified]
+    res = @db.exec_params('SELECT last_modified FROM quickbooks_time_jobs WHERE id=$1', [id])
+    changed = res.ntuples.zero? || res[0]['last_modified'] != last_modified
+    if changed
+      @db.exec_params(
+        'INSERT INTO quickbooks_time_jobs (
+          id, parent_id, name, short_code, type, billable, billable_rate,
+          has_children, assigned_to_all, required_customfields, filtered_customfielditems,
+          active, last_modified, created)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
+         ON CONFLICT (id) DO UPDATE SET
+           parent_id=EXCLUDED.parent_id,
+           name=EXCLUDED.name,
+           short_code=EXCLUDED.short_code,
+           type=EXCLUDED.type,
+           billable=EXCLUDED.billable,
+           billable_rate=EXCLUDED.billable_rate,
+           has_children=EXCLUDED.has_children,
+           assigned_to_all=EXCLUDED.assigned_to_all,
+           required_customfields=EXCLUDED.required_customfields,
+           filtered_customfielditems=EXCLUDED.filtered_customfielditems,
+           active=EXCLUDED.active,
+           last_modified=EXCLUDED.last_modified,
+           created=EXCLUDED.created',
+        [id, job['parent_id'], job['name'], job['short_code'], job['type'], job['billable'], job['billable_rate'], job['has_children'], job['assigned_to_all'], (job['required_customfields'] || []).to_json, (job['filtered_customfielditems'] || []).to_json, job['active'], last_modified, job['created']]
+      )
+    end
     changed
   end
 end

--- a/lib/quickbooks_time/repos/timesheets_repo.rb
+++ b/lib/quickbooks_time/repos/timesheets_repo.rb
@@ -1,14 +1,49 @@
 # frozen_string_literal: true
 
+require 'digest/sha1'
+
 class TimesheetsRepo
-  def initialize
-    @data = {}
+  def initialize(db:)
+    @db = db
   end
 
   def upsert(ts)
-    id = ts['id'] || ts[:id]
-    changed = @data[id] != ts
-    @data[id] = ts
-    changed
+    id        = ts['id'] || ts[:id]
+    job_id    = ts['jobcode_id'] || ts[:jobcode_id]
+    user_id   = ts['user_id'] || ts[:user_id]
+    date      = ts['date'] || ts[:date]
+    secs      = (ts['duration'] || ts[:duration]).to_i
+    notes     = (ts['notes'] || ts[:notes] || '').strip
+    entry     = ts['type'] || ts[:type]
+    start_t   = ts['start'] || ts[:start]
+    end_t     = ts['end'] || ts[:end]
+    created   = ts['created'] || ts[:created]
+    modified  = ts['last_modified'] || ts[:last_modified]
+
+    hash = Digest::SHA1.hexdigest([user_id, date, secs, notes, entry, start_t, end_t].join('|'))
+    res = @db.exec_params('SELECT last_hash FROM quickbooks_time_timesheets WHERE id=$1', [id])
+    if res.ntuples.zero?
+      @db.exec_params(
+        'INSERT INTO quickbooks_time_timesheets (
+           id, quickbooks_time_jobsite_id, user_id, date, duration_seconds,
+           notes, last_hash, entry_type, start_time, end_time, created_qbt, modified_qbt)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)',
+        [id, job_id, user_id, date, secs, notes, hash, entry, start_t, end_t, created, modified]
+      )
+      true
+    elsif res[0]['last_hash'] != hash
+      @db.exec_params(
+        'UPDATE quickbooks_time_timesheets
+           SET quickbooks_time_jobsite_id=$1, user_id=$2, date=$3,
+               duration_seconds=$4, notes=$5, last_hash=$6,
+               entry_type=$7, start_time=$8, end_time=$9,
+               created_qbt=$10, modified_qbt=$11, updated_at=now()
+         WHERE id=$12',
+        [job_id, user_id, date, secs, notes, hash, entry, start_t, end_t, created, modified, id]
+      )
+      true
+    else
+      false
+    end
   end
 end

--- a/lib/quickbooks_time/repos/users_repo.rb
+++ b/lib/quickbooks_time/repos/users_repo.rb
@@ -1,14 +1,33 @@
 # frozen_string_literal: true
 
+require 'json'
+
 class UsersRepo
-  def initialize
-    @data = {}
+  def initialize(db:)
+    @db = db
   end
 
   def upsert(user)
     id = user['id'] || user[:id]
-    changed = @data[id] != user
-    @data[id] = user
+    last_modified = user['last_modified'] || user[:last_modified]
+    res = @db.exec_params('SELECT last_modified FROM quickbooks_time_users WHERE id=$1', [id])
+    changed = res.ntuples.zero? || res[0]['last_modified'] != last_modified
+    if changed
+      @db.exec_params(
+        'INSERT INTO quickbooks_time_users (id, first_name, last_name, username, email, active, last_modified, created, raw)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+         ON CONFLICT (id) DO UPDATE SET
+           first_name=EXCLUDED.first_name,
+           last_name=EXCLUDED.last_name,
+           username=EXCLUDED.username,
+           email=EXCLUDED.email,
+           active=EXCLUDED.active,
+           last_modified=EXCLUDED.last_modified,
+           created=EXCLUDED.created,
+           raw=EXCLUDED.raw',
+        [id, user['first_name'], user['last_name'], user['username'], user['email'], user['active'], last_modified, user['created'], user.to_json]
+      )
+    end
     changed
   end
 end


### PR DESCRIPTION
## Summary
- create schema helper to ensure QuickBooks Time tables and cursor-aware sync log
- switch QuickBooks Time loader to PostgreSQL connection and DB-backed repos
- persist users, jobs, timesheets, and sync cursor

## Testing
- `ruby test/missive_post_builder_test.rb`
- `ruby test/jobs_stream_pagination_test.rb`
- `ruby test/qbt_client_api_error_test.rb`


------
https://chatgpt.com/codex/tasks/task_e_68a5f8eecc2c832dbe2d4c6cbcd453de