### PR TITLE
Add Missive conversation tracking to QuickBooks Time entities

### DIFF
--- a/api/quickbooks_time/util/backfill_conversation_ids.rb
+++ b/api/quickbooks_time/util/backfill_conversation_ids.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'pg'
+require 'envkey' # Use dotenv for local development if needed
+
+# --- Configuration ---
+DB_PARAMS = {
+  dbname: 'ruby_jobsites',
+  user: ENV.fetch('PG_JOBSITES_UN', nil),
+  password: ENV.fetch('PG_JOBSITES_PW', nil),
+  host: 'localhost'
+}.freeze
+
+puts '--- Backfilling Missive conversation IDs ---'
+
+begin
+  conn = PG.connect(DB_PARAMS)
+  puts '✅ Database connection successful.'
+
+  puts "-> Ensuring missive_conversation_id columns exist..."
+  conn.exec(<<~SQL)
+    ALTER TABLE quickbooks_time_jobs
+      ADD COLUMN IF NOT EXISTS missive_conversation_id TEXT;
+    ALTER TABLE quickbooks_time_users
+      ADD COLUMN IF NOT EXISTS missive_conversation_id TEXT;
+  SQL
+  puts "   ...Done."
+
+  puts "-> Backfilling quickbooks_time_jobs from quickbooks_time_jobsite_conversations..."
+  conn.exec(<<~SQL)
+    UPDATE quickbooks_time_jobs j
+    SET missive_conversation_id = c.missive_conversation_id
+    FROM quickbooks_time_jobsite_conversations c
+    WHERE j.id = c.quickbooks_time_jobsite_id
+      AND j.missive_conversation_id IS NULL;
+  SQL
+  puts "   ...Done."
+
+  puts "\n✅ Backfill complete."
+rescue PG::Error => e
+  puts "\n❌ A database error occurred:"
+  puts e.message
+ensure
+  conn&.close
+  puts '-> Database connection closed.'
+end

--- a/lib/quickbooks_time/db/schema.rb
+++ b/lib/quickbooks_time/db/schema.rb
@@ -30,6 +30,7 @@ class QuickbooksTime
             active BOOLEAN,
             last_modified TIMESTAMPTZ,
             created TIMESTAMPTZ,
+            missive_conversation_id TEXT,
             raw JSONB
           );
         SQL
@@ -51,7 +52,8 @@ class QuickbooksTime
             filtered_customfielditems JSONB,
             active BOOLEAN,
             last_modified TIMESTAMPTZ,
-            created TIMESTAMPTZ
+            created TIMESTAMPTZ,
+            missive_conversation_id TEXT
           );
         SQL
       end

--- a/lib/quickbooks_time/repos/jobs_repo.rb
+++ b/lib/quickbooks_time/repos/jobs_repo.rb
@@ -17,8 +17,8 @@ class JobsRepo
         'INSERT INTO quickbooks_time_jobs (
           id, parent_id, name, short_code, type, billable, billable_rate,
           has_children, assigned_to_all, required_customfields, filtered_customfielditems,
-          active, last_modified, created)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
+          active, last_modified, created, missive_conversation_id)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
          ON CONFLICT (id) DO UPDATE SET
            parent_id=EXCLUDED.parent_id,
            name=EXCLUDED.name,
@@ -32,8 +32,9 @@ class JobsRepo
            filtered_customfielditems=EXCLUDED.filtered_customfielditems,
            active=EXCLUDED.active,
            last_modified=EXCLUDED.last_modified,
-           created=EXCLUDED.created',
-        [id, job['parent_id'], job['name'], job['short_code'], job['type'], job['billable'], job['billable_rate'], job['has_children'], job['assigned_to_all'], (job['required_customfields'] || []).to_json, (job['filtered_customfielditems'] || []).to_json, job['active'], last_modified, job['created']]
+           created=EXCLUDED.created,
+           missive_conversation_id=EXCLUDED.missive_conversation_id',
+        [id, job['parent_id'], job['name'], job['short_code'], job['type'], job['billable'], job['billable_rate'], job['has_children'], job['assigned_to_all'], (job['required_customfields'] || []).to_json, (job['filtered_customfielditems'] || []).to_json, job['active'], last_modified, job['created'], job['missive_conversation_id']]
       )
     end
     changed

--- a/lib/quickbooks_time/repos/users_repo.rb
+++ b/lib/quickbooks_time/repos/users_repo.rb
@@ -14,8 +14,8 @@ class UsersRepo
     changed = res.ntuples.zero? || res[0]['last_modified'] != last_modified
     if changed
       @db.exec_params(
-        'INSERT INTO quickbooks_time_users (id, first_name, last_name, username, email, active, last_modified, created, raw)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+        'INSERT INTO quickbooks_time_users (id, first_name, last_name, username, email, active, last_modified, created, missive_conversation_id, raw)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
          ON CONFLICT (id) DO UPDATE SET
            first_name=EXCLUDED.first_name,
            last_name=EXCLUDED.last_name,
@@ -24,8 +24,9 @@ class UsersRepo
            active=EXCLUDED.active,
            last_modified=EXCLUDED.last_modified,
            created=EXCLUDED.created,
+           missive_conversation_id=EXCLUDED.missive_conversation_id,
            raw=EXCLUDED.raw',
-        [id, user['first_name'], user['last_name'], user['username'], user['email'], user['active'], last_modified, user['created'], user.to_json]
+        [id, user['first_name'], user['last_name'], user['username'], user['email'], user['active'], last_modified, user['created'], user['missive_conversation_id'], user.to_json]
       )
     end
     changed


### PR DESCRIPTION
## Summary
- add `missive_conversation_id` column to `quickbooks_time_users` and `quickbooks_time_jobs`
- update UsersRepo and JobsRepo upsert methods to handle the new column
- provide migrations and backfill script for the new column

## Testing
- `ruby -Ilib:test test/jobs_stream_pagination_test.rb`
- `ruby -Ilib:test test/socket_extensions_ebadf_test.rb` *(fails: expected `[[ :data, "hi"], [:disconnect, nil]]`]*

------
https://chatgpt.com/codex/tasks/task_e_68a8888f39a4832d8b3fa63f3d066f3f